### PR TITLE
chore: split up rabbit mq env vars so we can provide through k8s config

### DIFF
--- a/src/config/rabbitmq.ts
+++ b/src/config/rabbitmq.ts
@@ -2,7 +2,10 @@ import amqp from "amqplib";
 import logger from "../utils/logger";
 
 export const rabbitMQConfig = {
-  url: process.env.RABBITMQ_URL || "amqp://guest:guest@localhost:5672",
+  hostname: process.env.RABBITMQ_HOST || "localhost",
+  port: Number(process.env.RABBITMQ_PORT) || 5672,
+  username: process.env.RABBITMQ_USERNAME || "guest",
+  password: process.env.RABBITMQ_PASSWORD || "guest",
   exchange: "webhook_exchange",
   queueBackendCore: "backend_core_queue",
   queueTestRunner: "test_runner_queue",
@@ -14,7 +17,13 @@ let channel: amqp.Channel | null = null;
 
 export async function setupRabbitMQ() {
   try {
-    connection = await amqp.connect(rabbitMQConfig.url);
+    connection = await amqp.connect({
+      protocol: "amqp",
+      hostname: rabbitMQConfig.hostname,
+      port: rabbitMQConfig.port,
+      username: rabbitMQConfig.username,
+      password: rabbitMQConfig.password,
+    });
     channel = await connection.createChannel();
 
     await channel.assertExchange(rabbitMQConfig.exchange, "topic", {


### PR DESCRIPTION
# Split RabbitMQ Connection URL into Separate Configuration Properties

## Changes
- Modify `rabbitMQConfig` to use individual connection properties instead of a single URL
- Add separate properties for hostname, port, username, and password
- Use environment variables with fallback values for each property

## Before
```typescript
export const rabbitMQConfig = {
url: process.env.RABBITMQ_URL || "amqp://guest:guest@localhost:5672",
// ... other properties
};
```

## After
```typescript
export const rabbitMQConfig = {
hostname: process.env.RABBITMQ_HOST || "localhost",
port: Number(process.env.RABBITMQ_PORT) || 5672,
username: process.env.RABBITMQ_USERNAME || "guest",
password: process.env.RABBITMQ_PASSWORD || "guest",
// ... other properties
};
```

## Purpose
- Allow for more flexible configuration in Kubernetes environments
- Enable separate specification of RabbitMQ connection properties

## Implementation
- Replace single `url` property with individual connection properties
- Use environment variables for each property with sensible defaults

## Testing
- Verify application correctly reads individual environment variables
- Ensure fallback values work when environment variables are not set
- Test connection to RabbitMQ using the new configuration format
